### PR TITLE
Portfolio accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       crossorigin="anonymous"
     ></script>
     <link rel="stylesheet" href="style.css" />
-    <title>Portfolio</title>
+    <title>Dave Portfolio</title>
   </head>
   <body>
     <!-- ================== Header ====================== -->
@@ -102,7 +102,7 @@
           <div class="grid limit-desk">
             <article class="main-article flex flex-col flex-center">
               <div class="article-img">
-                <img src="./assets/images/Img-Placeholder.png" alt="" />
+                <img src="./assets/images/Img-Placeholder.png" alt="illustration of a woman practising yoga"/>
               </div>
 
               <div class="article-block flex flex-col start-col">
@@ -291,7 +291,7 @@
           </div>
 
           <div class="line">
-            <img src="./assets/images/Devider.png" alt="devider" />
+            <img src="./assets/images/Devider.png" alt="image used to divide sections" />
           </div>
 
           <div class="second-container">
@@ -299,7 +299,7 @@
               <h3 class="lang-title flex">
                 <img
                   src="./assets/images/Rectangle-55.svg"
-                  alt="rotated rectangle"
+                  alt="image of a rotated rectangle"
                 />Language
               </h3>
               <ul class="languages flex">
@@ -312,7 +312,7 @@
 
             <div class="cont">
               <h3 class="lang-title flex">
-                <img src="./assets/images/Rectangle-56.svg" alt="rectangle" />
+                <img src="./assets/images/Rectangle-56.svg" alt="image of a small rectangle" />
                 Frameworks
               </h3>
               <ul class="languages flex">
@@ -326,7 +326,7 @@
 
             <div class="cont">
               <h3 class="lang-title flex">
-                <img src="./assets/images/Rectangle-57.svg" alt="circle" /> Skills
+                <img src="./assets/images/Rectangle-57.svg" alt="image of a circle" /> Skills
               </h3>
               <ul class="languages flex">
                 <li>Codekit</li>

--- a/style.css
+++ b/style.css
@@ -582,6 +582,11 @@ form input[type="submit"] {
   position: relative;
 }
 
+.contact-form form input:focus,
+.contact-form form textarea:focus {
+  outline: 1px solid var(--hColor);
+}
+
 .contact-second::after {
   content: "";
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -170,7 +170,7 @@ select {
 /* ............. Header............... */
 
 header.limit {
-  height: 7.4539vh;
+  min-height: 7.4539vh;
   width: 100%;
   background-color: #3c3a39;
   color: #fff;
@@ -237,8 +237,11 @@ main {
 
 .hero {
   width: 100%;
-  height: calc(100vh - 7.4539vh);
+  min-height: calc(100vh - 7.4539vh);
   margin-bottom: 7.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .hero-container {
@@ -716,7 +719,7 @@ form input[type="submit"] {
   .hero-title h3::after {
     content: "";
     position: absolute;
-    top: 8rem;
+    top: -6rem;
     right: 8rem;
     width: 2rem;
     height: 2rem;


### PR DESCRIPTION
# Portfolio Accessibility
## In this branch we check the following elements:
- Title: Changed from [__"Portfolio"__](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/main/index.html#L18) to [__"Dave Portfolio"__](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L18)
- Images text Alt: Added text to and modified the text of these "alt" attributes :
  - [Work section](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L105) image;
  - About  Me section: [first](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L294) image, [second](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L302) image, [third](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L315) image, [fourth](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/index.html#L329) image.
- Text Heading: No issues.
- Color contrast: No issues(Used template's colors).
- Resize: Changed the __height__ property to __min-height__ in [this](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/style.css#L668-L675) hero section container and [this](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/style.css#L668-L675) header container to ease text zoom.
- Interaction: Added outline when a user focuses on the [input fields](https://github.com/DaveZag/Portfolio-setup-and-mobile-first/blob/feature-access/style.css#L585-L588).
- Moving Content: No issues.
- Multimedia: None was used in the project.
- The basic structure of the page: No issues.

---
